### PR TITLE
Fix/isolate legacy pref

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Legacy EncryptedSharedPreferences
 ```dart
 void main() async {
   final key = "";
-  await EncryptedSharedPreferences.initialize(key: key);
-  var sharedPref = EncryptedSharedPreferences.getInstance();
+  var sharedPref = await EncryptedSharedPreferences.create(key: key);
+  
 
   await sharedPref.setString(
       'user_token', 'xxxxxxxxxxxx', notify: true); ////notify = true by default

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,10 +20,10 @@ class CustomEncryptorAlgorithm implements IEncryptor {
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await EncryptedSharedPreferences.initialize('1111111111111111');
-  EncryptedSharedPreferences.getInstance().setString('dataKey1', 'dataValue');
-  EncryptedSharedPreferences.getInstance().setString('dataKey2', 'dataValue');
-  EncryptedSharedPreferences.getInstance().setString('dataKey3', 'dataValue');
+  final EncryptedSharedPreferences legacyPrefs = await EncryptedSharedPreferences.create('1111111111111111');
+  legacyPrefs.setString('dataKey1', 'dataValue');
+  legacyPrefs.setString('dataKey2', 'dataValue');
+  legacyPrefs.setString('dataKey3', 'dataValue');
   runApp(const MyApp());
 }
 
@@ -35,40 +35,46 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
+  late EncryptedSharedPreferences legacyPrefs;
+
+  @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+  }
+
+  Future setInstance() async {
+    legacyPrefs = await EncryptedSharedPreferences.create('1111111111111111');
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        body: SharedBuilder(
-          listenKeys: const {"key1", "key2"}, //Optional
-          builder: (EncryptedSharedPreferences encryptedSharedPreferences,
-              String? updatedKey) {
-            return Text(
-                "value : ${encryptedSharedPreferences.getString("key1")}");
-          },
-        ),
-        appBar: AppBar(
-          title: const Text('Shared Builder Demo'),
-        ),
-        floatingActionButton: Column(children: [
-          FloatingActionButton(
-            onPressed: () async {
-              EncryptedSharedPreferences.getInstance()
-                  .setString('key1', Random().nextInt(100).toString());
-              Future.delayed(const Duration(seconds: 3), () {
-                EncryptedSharedPreferences.getInstance()
-                    .setString('key2', 'dataValue');
-              });
+          body: SharedBuilder(
+            listenKeys: const {"key1", "key2"}, //Optional
+            builder: (EncryptedSharedPreferences encryptedSharedPreferences, String? updatedKey) {
+              return Text("value : ${encryptedSharedPreferences.getString("key1")}");
             },
           ),
-          FloatingActionButton(
-            onPressed: () async {
-              EncryptedSharedPreferences.getInstance()
-                  .setString('Random key ${Random().nextInt(100)}', Random().nextInt(100).toString());
-            }
+          appBar: AppBar(
+            title: const Text('Shared Builder Demo'),
           ),
-        ],)
-      ),
+          floatingActionButton: Column(
+            children: [
+              FloatingActionButton(
+                onPressed: () async {
+                  legacyPrefs.setString('key1', Random().nextInt(100).toString());
+                  Future.delayed(const Duration(seconds: 3), () {
+                    legacyPrefs.setString('key2', 'dataValue');
+                  });
+                },
+              ),
+              FloatingActionButton(onPressed: () async {
+                legacyPrefs.setString('Random key ${Random().nextInt(100)}', Random().nextInt(100).toString());
+              }),
+            ],
+          )),
     );
   }
 }

--- a/lib/src/extension/shared_preferences_devtools_extension_data.dart
+++ b/lib/src/extension/shared_preferences_devtools_extension_data.dart
@@ -36,7 +36,8 @@ class SharedPreferencesDevToolsExtensionData {
 
   Future<void> listenChanges() async {
     try {
-      EncryptedSharedPreferences.getInstance().observe().listen((key) {
+      final EncryptedSharedPreferences legacyPrefs = await EncryptedSharedPreferences.create(encryptionKey);
+      legacyPrefs.observe().listen((key) {
         _postEvent(
           '${_eventPrefix}listenChanges',
           {'key': key},
@@ -60,8 +61,7 @@ class SharedPreferencesDevToolsExtensionData {
 
   /// Requests all legacy and async keys and post an event with the result.
   Future<void> requestAllKeys() async {
-    final EncryptedSharedPreferences legacyPrefs =
-        EncryptedSharedPreferences.getInstance();
+    final EncryptedSharedPreferences legacyPrefs = await EncryptedSharedPreferences.create(encryptionKey);
     Set<String> legacyKeys = {};
     Set<String> asyncKeys = {};
     try {
@@ -86,8 +86,7 @@ class SharedPreferencesDevToolsExtensionData {
   Future<void> requestValue(String key, bool legacy) async {
     final Object? value;
     if (legacy) {
-      final EncryptedSharedPreferences legacyPrefs =
-          EncryptedSharedPreferences.getInstance();
+      final EncryptedSharedPreferences legacyPrefs = await EncryptedSharedPreferences.create(key);
       value = legacyPrefs.get(key);
     } else {
       final EncryptedSharedPreferencesAsync preferences =
@@ -114,8 +113,7 @@ class SharedPreferencesDevToolsExtensionData {
   ) async {
     final Object? value = jsonDecode(serializedValue);
     if (legacy) {
-      final EncryptedSharedPreferences legacyPrefs =
-          EncryptedSharedPreferences.getInstance();
+      final EncryptedSharedPreferences legacyPrefs = await EncryptedSharedPreferences.create(key);
       // we need to check the kind because sometimes a double
       // gets interpreted as an int. If this was not an issue
       // we'd only need to do a simple pattern matching on value.
@@ -139,8 +137,7 @@ class SharedPreferencesDevToolsExtensionData {
           );
       }
     } else {
-      final EncryptedSharedPreferencesAsync prefs =
-          EncryptedSharedPreferencesAsync(encryptionKey);
+      final EncryptedSharedPreferencesAsync prefs = EncryptedSharedPreferencesAsync(encryptionKey);
       // we need to check the kind because sometimes a double
       // gets interpreted as an int. If this was not an issue
       // we'd only need to do a simple pattern matching on value.
@@ -170,8 +167,7 @@ class SharedPreferencesDevToolsExtensionData {
   /// Requests a key removal and posts an empty event when removed.
   Future<void> requestRemoveKey(String key, bool legacy) async {
     if (legacy) {
-      final EncryptedSharedPreferences legacyPrefs =
-          EncryptedSharedPreferences.getInstance();
+      final EncryptedSharedPreferences legacyPrefs = await EncryptedSharedPreferences.create(key);
       await legacyPrefs.remove(key);
     } else {
       await EncryptedSharedPreferencesAsync(encryptionKey).remove(key);

--- a/lib/src/extension/shared_preferences_devtools_extension_data.dart
+++ b/lib/src/extension/shared_preferences_devtools_extension_data.dart
@@ -46,7 +46,7 @@ class SharedPreferencesDevToolsExtensionData {
       print('Legacy api not initialized');
     }
     try {
-      EncryptedSharedPreferencesAsync.getInstance().observe().listen((key) {
+      EncryptedSharedPreferencesAsync(encryptionKey).observe().listen((key) {
         _postEvent(
           '${_eventPrefix}listenChanges',
           {'key': key},

--- a/lib/src/ui/shared_builder.dart
+++ b/lib/src/ui/shared_builder.dart
@@ -1,29 +1,40 @@
 import 'package:encrypt_shared_preferences/provider.dart';
 import 'package:flutter/material.dart';
 
-class SharedBuilder extends StatelessWidget {
+class SharedBuilder extends StatefulWidget {
   final Set<String>? listenKeys;
-  final Widget Function(
-      EncryptedSharedPreferences preferences, String? updatedKey) builder;
-
-  final EncryptedSharedPreferences _preferences =
-      EncryptedSharedPreferences.getInstance();
+  final Widget Function(EncryptedSharedPreferences preferences, String? updatedKey) builder;
 
   @override
-  Widget build(BuildContext context) {
-    return StreamBuilder(
-      stream: listenKeys != null
-          ? _preferences.observeSet(keys: listenKeys!)
-          : _preferences.observe(),
-      builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
-        return builder(_preferences, snapshot.data);
-      },
-    );
-  }
+  State<SharedBuilder> createState() => _SharedBuilderState();
 
-  SharedBuilder({
+  const SharedBuilder({
     super.key,
     this.listenKeys,
     required this.builder,
   });
+}
+
+class _SharedBuilderState extends State<SharedBuilder> {
+  late EncryptedSharedPreferences _preferences;
+
+  @override
+  void initState() {
+    setInsatnce();
+    super.initState();
+  }
+
+  Future setInsatnce() async {
+    _preferences = await EncryptedSharedPreferences.create("1111111111111111");
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder(
+      stream: widget.listenKeys != null ? _preferences.observeSet(keys: widget.listenKeys!) : _preferences.observe(),
+      builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
+        return widget.builder(_preferences, snapshot.data);
+      },
+    );
+  }
 }

--- a/test/encrypted_shared_preferences_test.dart
+++ b/test/encrypted_shared_preferences_test.dart
@@ -4,8 +4,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
   SharedPreferences.setMockInitialValues({});
-  await EncryptedSharedPreferences.initialize("1111111111111111");
-  final sharedPref = EncryptedSharedPreferences.getInstance();
+  final sharedPref = await EncryptedSharedPreferences.create("1111111111111111");
+
   await sharedPref.clear();
 
   test('test listen key', () async {
@@ -126,14 +126,12 @@ void main() async {
       "key1"
           "key3"
     };
-    await sharedPref.removeWhere(
-        condition: (key, value) => saveKeySet.contains(key));
+    await sharedPref.removeWhere(condition: (key, value) => saveKeySet.contains(key));
     expect(sharedPref.getString("key2"), "value2");
   });
 
   test('test defaultValue', () {
-    final strValue =
-        sharedPref.getString("key10", defaultValue: "defaultKey10Value");
+    final strValue = sharedPref.getString("key10", defaultValue: "defaultKey10Value");
     final intValue = sharedPref.getInt("key11", defaultValue: 1011);
     final doubleValue = sharedPref.getDouble("key12", defaultValue: 1.23);
     final boolValue = sharedPref.getBoolean("key13", defaultValue: false);
@@ -147,8 +145,7 @@ void main() async {
   });
 
   test('test saving string list value', () async {
-    final strValue = await sharedPref
-        .setStringList("stringList", ["apple", "orange", "boom"]);
+    final strValue = await sharedPref.setStringList("stringList", ["apple", "orange", "boom"]);
     expect(strValue, true);
     final actual = sharedPref.getStringList('stringList');
     expect(actual, ["apple", "orange", "boom"]);


### PR DESCRIPTION
### Type of change
Fix for issue: https://github.com/xaldarof/encrypted-shared-preferences/issues/16

### Description
It was observed that @xaldarof had already fixed the issue for `EncryptedSharedPreferencesAsync` hence I have fixed it for `EncryptedSharedPreferences`

**🔒 Add create factory method to initialize EncryptedSharedPreferences with AES encryption**

This PR introduces a create factory method to the EncryptedSharedPreferences class. It encapsulates the setup of the encrypted preferences instance using AES encryption and a password-based key.

**Details:**
- Accepts a password to initialize the AES encryptor.
- Loads the platform’s default SharedPreferences instance.
- Wraps it with encryption using SharedPreferencesDecorator and AesEncryptor.
- Returns a fully configured EncryptedSharedPreferences instance via a Future.

**Benefits:**
- Simplifies initialization logic for consumers.
- Ensures consistent and secure setup of encrypted preferences.
- Prepares the class for future extensibility or changes in encryption setup.

**Example usage:**
```
final prefs = await EncryptedSharedPreferences.create(password: 'my-secret-key');
await prefs.setString('secureKey', 'secureValue');
```

### Checklist
- [x] I have tested these changes locally
- [x] I have added appropriate comments/documentation
- [x] I have passed all test cases
- [x] I have checked for potential breaking changes
